### PR TITLE
Restrict braiding to unitary cases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QWignerSymbols"
 uuid = "a6ec71dc-95d1-4ca4-9dd3-50060f27aa2b"
 authors = ["Lukas Devos <ldevos98@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
@@ -11,7 +11,7 @@ WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
 [compat]
 HalfIntegers = "1"
 Random = "1"
-TensorKitSectors = "0.3.5"
+TensorKitSectors = "0.3.7"
 TensorOperations = "5"
 WignerSymbols = "2"
 julia = "1.10"

--- a/src/SU2qIrrep.jl
+++ b/src/SU2qIrrep.jl
@@ -70,11 +70,14 @@ Base.hash(s::SU2qIrrep, h::UInt) = hash(s.j, h)
 Base.isless(s1::T, s2::T) where {T <: SU2qIrrep} = isless(s1.j, s2.j)
 
 FusionStyle(::Type{<:SU2qIrrep}) = SimpleFusion()
-BraidingStyle(::Type{<:SU2qIrrep}) = Anyonic()
+BraidingStyle(::Type{SU2qIrrep{Q}}) where {Q} = Q isa RootOfUnity ? Anyonic() : NoBraiding()
 
 TensorKitSectors.fusionscalartype(::Type{I}) where {I <: SU2qIrrep} = float(typeof(q(I)))
 TensorKitSectors.sectorscalartype(::Type{I}) where {I <: SU2qIrrep} = float(typeof(q(I)))
-TensorKitSectors.braidingscalartype(::Type{I}) where {I <: SU2qIrrep} = float(typeof(q(I)))
+function TensorKitSectors.braidingscalartype(::Type{I}) where {I <: SU2qIrrep}
+    BraidingStyle(I) === NoBraiding() && throw(ArgumentError("No braiding for sector $I"))
+    return float(typeof(q(I)))
+end
 
 # ------------------------------------------------------------------------------------
 #


### PR DESCRIPTION
If `q` isn't a root of unity, it turns out that the braiding can't be made unitary, so I propose to make them not braided at all.